### PR TITLE
Fix for https://github.com/qca/open-ath9k-htc-firmware/issues/8

### DIFF
--- a/target_firmware/magpie_fw_dev/build/utility/Makefile
+++ b/target_firmware/magpie_fw_dev/build/utility/Makefile
@@ -1,7 +1,10 @@
 DIRS = bin2hex
+TARGET_DIR = ./bin
 
 all:
+	@mkdir -p $(TARGET_DIR)
 	@for i in $(DIRS) ; do $(MAKE) -C $$i || exit $? ; done
 
 clean :
 	@for i in $(DIRS) ; do $(MAKE) -C $$i clean; done
+	@rm -r $(TARGET_DIR)

--- a/target_firmware/magpie_fw_dev/build/utility/bin2hex/Makefile
+++ b/target_firmware/magpie_fw_dev/build/utility/bin2hex/Makefile
@@ -1,10 +1,11 @@
 TARGET = ../bin/bin2hex		# for Linux environment
-
+TARGET_DIR = ../bin
 E=echo
 
 all: $(TARGET)
 
 $(TARGET):
+	@mkdir -p $(TARGET_DIR)
 	gcc -o $(TARGET) bin2hex.c
 	@$(E) "  CC " $@
 


### PR DESCRIPTION
If target_firmware/magpie_fw_dev/build/utility/bin is not created
before compiling bin2hex build will fail.

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
