### PR TITLE
Add UART documentation

### DIFF
--- a/docs/uart
+++ b/docs/uart
@@ -1,0 +1,4 @@
+Name     | TX pin | TX GPIO | RX pin | RX GPIO | Baudrate
+---------+--------+---------+--------+---------+--------
+AR9271   |   48   |  GPIO9  |   49   |  GPIO10 | 19200
+AR7010   |   54   |  GPIO8  |   52   |  GPIO9  | 115200


### PR DESCRIPTION
Specify to which pin/GPIO UART is connected
for both AR9271 and AR7010

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
