### PR TITLE
Add build information to the beginning of the binary

### DIFF
--- a/target_firmware/magpie_fw_dev/build/utility/athfw2lnx/Makefile
+++ b/target_firmware/magpie_fw_dev/build/utility/athfw2lnx/Makefile
@@ -5,7 +5,7 @@ $(error "ERROR: usage: make ATH_FW=fw.c")
 endif
 
 athfw2lnx: athfw2lnx.c $(ATH_FW)
-	gcc -o $@ athfw2lnx.c $(ATH_FW)
+	gcc -o $@ athfw2lnx.c $(ATH_FW) -DHOSTNAME=\"$(shell hostname)\"  -DCOMMIT_HASH=\"$(shell git rev-parse --short HEAD)\"
 
 clean:
 	rm -f athfw2lnx

--- a/target_firmware/magpie_fw_dev/build/utility/athfw2lnx/athfw2lnx.c
+++ b/target_firmware/magpie_fw_dev/build/utility/athfw2lnx/athfw2lnx.c
@@ -35,14 +35,35 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdint.h>
+#include <string.h>
 
 /* These names may vary but this is typical */
 extern const uint32_t zcFwImage[];
 extern const uint32_t zcFwImageSize;
 
+#define WLAN_BUILD_VER_MAJOR 1
+#define WLAN_BUILD_VER_MINOR 1
+#define WLAN_BUILD_VER_TAG 1
+
+struct build_info {
+	uint32_t	major;
+	uint32_t	minor;
+	uint32_t	tag;
+	char		commit_id[40];
+	char		user_name[32];
+};
 int main()
 {
 	uint32_t i;
+	struct build_info binfo;
+
+	binfo.major	= WLAN_BUILD_VER_MAJOR;
+	binfo.minor	= WLAN_BUILD_VER_MINOR;
+	binfo.tag	= WLAN_BUILD_VER_TAG;
+	memcpy(binfo.user_name, HOSTNAME, strlen(HOSTNAME));
+	memcpy(binfo.commit_id, COMMIT_HASH, strlen(COMMIT_HASH));
+	write(1, &binfo, sizeof(binfo));
+
 	for (i = 0; i < zcFwImageSize/4; i++)
 		write(1, &zcFwImage[i], 4);
 }


### PR DESCRIPTION
With this commit both htc_9271.fw and htc_7010.fw will have build
information in the beginning of the file. Driver can read this
information even before loading fw to the chip.

Build information format:
    u32 major;
    u32 minor;
    u32 tag;
    char    commit_id[40];
    char    user_name[32];

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
