### PR TITLE
Remove unused variable i for bGet_descriptor_patch().

### DIFF
--- a/target_firmware/magpie_fw_dev/target/hif/k2_fw_usb_api.c
+++ b/target_firmware/magpie_fw_dev/target/hif/k2_fw_usb_api.c
@@ -734,7 +734,6 @@ uint16_t ConfigDescriptorPatch[30];
 
 BOOLEAN bGet_descriptor_patch(void)
 {
-    int i;
     switch (mDEV_REQ_VALUE_HIGH()) {
     case 1:
         ath_hal_memcpy(DeviceDescriptorPatch,


### PR DESCRIPTION
bGet_descriptor_patch() doesn't use the variable `i` at all. Remove it.
