### PR TITLE
Fix Array Out of Bounds in rcSibUpdate_ht()

### DIFF
--- a/target_firmware/wlan/ratectrl.h
+++ b/target_firmware/wlan/ratectrl.h
@@ -117,10 +117,8 @@ enum {
 
 #ifdef MAGPIE_MERLIN  
 #define MAX_TX_RATE_TBL         46
-#define MAX_TX_RATE_PHY         48
 #else
 #define MAX_TX_RATE_TBL         54//46
-#define MAX_TX_RATE_PHY         56//48
 #endif
 
 /*

--- a/target_firmware/wlan/ratectrl_11n_ln.c
+++ b/target_firmware/wlan/ratectrl_11n_ln.c
@@ -369,7 +369,7 @@ rcSibUpdate_ht(struct ath_softc_tgt *sc, struct ath_node_target *an,
 	rcInitValidTxMask(pRc);
 
 	for (i = 0; i < WLAN_RC_PHY_MAX; i++) {
-		for (j = 0; j < MAX_TX_RATE_PHY; j++) {
+		for (j = 0; j < MAX_TX_RATE_TBL; j++) {
 			mPhyCtrlState.validPhyRateIndex[i][j] = 0;
 		}   
 		mPhyCtrlState.validPhyRateCount[i] = 0;


### PR DESCRIPTION
In rcSibUpdate_ht(), we clear
validPhyRateIndex[WLAN_RC_PHY_MAX][MAX_TX_RATE_PHY]
by a for loop.

But, validPhyRateIndex was defined with
validPhyRateIndex[WLAN_RC_PHY_MAX][MAX_TX_RATE_TBL],
and MAX_TX_RATE_TBL is always greater than MAX_TX_RATE_PHY,
caused the out of bounds array access.

This commit corrects MAX_TX_RATE_PHY to MAX_TX_RATE_TBL,
and remove MAX_TX_RATE_PHY from ratectrl.h because it is
no longer be used.

Signed-off-by: Tom Li biergaizi@member.fsf.org
