### PR TITLE
ath9k_htc_firmware: check only the mesh control present subfield

### DIFF
--- a/target_firmware/wlan/ieee80211_output.c
+++ b/target_firmware/wlan/ieee80211_output.c
@@ -74,7 +74,7 @@ ieee80211_tgt_crypto_encap(struct ieee80211_frame *wh,
 
 	/* set the offset to 32 if the mesh control field is present */
 	wh_mesh = (struct ieee80211_qosframe_addr4 *)wh;
-	if (wh_mesh->i_qos[1] == 0x01)
+	if (wh_mesh->i_qos[1] & 0x01)
 		offset = 32;
 
 	iv = (a_uint8_t *) wh;


### PR DESCRIPTION
This is related to the previous patch "fix the offset of
CCMP header for mesh data frame". Check only the Mesh
Control Present subfield on QoS Control field to determine
whether it is a mesh data frame.

Signed-off-by: Chun-Yeow Yeoh yeohchunyeow@gmail.com
