### PR TITLE
remove __DATE__ and __TIME__

### DIFF
--- a/target_firmware/magpie_fw_dev/target/inc/k2/k2/rom_cfg.h
+++ b/target_firmware/magpie_fw_dev/target/inc/k2/k2/rom_cfg.h
@@ -62,14 +62,11 @@
 #define ATH_VER_MINOR_NUMBER        "0"
 #define ATH_VER_BUILD_NUMBER        "3"
 
-#define ATH_VER_DATES               __DATE__" "__TIME__
-
 #define ATH_VERSION_STR             "["ATH_VER_RELEASE_CODE       "."	\
 	ATH_VER_PLATFORM_NUMBER "."					\
 	ATH_VER_MAJOR_NUMBER    "."					\
 	ATH_VER_MINOR_NUMBER    "."					\
-	ATH_VER_BUILD_NUMBER    "] "					\
-	ATH_VER_DATES
+	ATH_VER_BUILD_NUMBER    "]"
 
 /* ROM Code Version (16 bit)
  * Bit 15   : 0 means ASIC, 1 means FPGA

--- a/target_firmware/magpie_fw_dev/target/inc/magpie/magpie/rom_cfg.h
+++ b/target_firmware/magpie_fw_dev/target/inc/magpie/magpie/rom_cfg.h
@@ -62,14 +62,11 @@
 #define ATH_VER_MINOR_NUMBER        "0"
 #define ATH_VER_BUILD_NUMBER        "3"
 
-#define ATH_VER_DATES               __DATE__" "__TIME__
-
 #define ATH_VERSION_STR             "["ATH_VER_RELEASE_CODE       "." \
                                     ATH_VER_PLATFORM_NUMBER "." \
                                     ATH_VER_MAJOR_NUMBER    "." \
                                     ATH_VER_MINOR_NUMBER    "." \
-                                    ATH_VER_BUILD_NUMBER    "] " \
-                                    ATH_VER_DATES
+                                    ATH_VER_BUILD_NUMBER    "]"
 
 /* ROM Code Version (16 bit)
  * Bit 15   : 0 means ASIC, 1 means FPGA

--- a/target_firmware/magpie_fw_dev/target/init/init.c
+++ b/target_firmware/magpie_fw_dev/target/init/init.c
@@ -65,8 +65,6 @@ uint32_t idle_cnt = 0;
 int (* save_cmnos_printf)(const char * fmt, ...);
 #endif
 
-#define ATH_DATE_STRING     __DATE__" "__TIME__
-
 static void idle_task();
 
 #if defined(PROJECT_MAGPIE)


### PR DESCRIPTION
__DATE__ and __TIME__ are mostly useless information.
Even more, it makes builds not reprodusable which is evil.

Read more about reproducible builds here:
https://reproducible-builds.org/

Signed-off-by: Oleksij Rempel <linux@rempel-privat.de>