### PR TITLE
Only increment xretries statistic for unicast frames

### DIFF
--- a/target_firmware/wlan/if_owl.c
+++ b/target_firmware/wlan/if_owl.c
@@ -1026,13 +1026,15 @@ static void
 ath_update_stats(struct ath_softc_tgt *sc, struct ath_tx_buf *bf)
 {
 	struct ath_tx_desc *ds = bf->bf_desc;
+	struct ieee80211_frame *wh = ATH_SKB2_WH(bf->bf_skb);
 	u_int32_t sr, lr;
 
 	if (ds->ds_txstat.ts_status == 0) {
 		if (ds->ds_txstat.ts_rate & HAL_TXSTAT_ALTRATE)
 			sc->sc_tx_stats.ast_tx_altrate++;
 	} else {
-		if (ds->ds_txstat.ts_status & HAL_TXERR_XRETRY)
+		if (ds->ds_txstat.ts_status & HAL_TXERR_XRETRY &&
+		    !IEEE80211_IS_MULTICAST(wh->i_addr1))
 			sc->sc_tx_stats.ast_tx_xretries++;
 		if (ds->ds_txstat.ts_status & HAL_TXERR_FIFO)
 			sc->sc_tx_stats.ast_tx_fifoerr++;


### PR DESCRIPTION
It looks like the ar5416 only has the AR_ExcessiveRetries flag
to let the outside know it didn't receive an ACK.

So in case of broadcast/multicast it gets set even though it's
not "excessive retry" per se. These frames just don't
acknowledge/retry in a 802.11 transmission.

This patch makes sure broadcast/multicast transmissions won't
increment the xretries statistic.