### PR TITLE
make toolchain path configurable

### DIFF
--- a/target_firmware/configure
+++ b/target_firmware/configure
@@ -35,28 +35,24 @@
  # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ##
 
-TOOLCHAIN=$PWD/../toolchain/inst
-
 TARGET=xtensa-elf
-PREFIX="$TOOLCHAIN/bin/$TARGET-"
-TOOLCHAIN_FILE=$PWD/build/toolchain.cmake
+
+[ -z "$CROSS_COMPILE" ] &&
+    CROSS_COMPILE="$PWD/../toolchain/inst/bin/$TARGET-"
+
+TOOLCHAIN_FILE="$PWD/build/toolchain.cmake"
 
 set -e
 rm -rf build
 mkdir -p build
 
 cat > "$TOOLCHAIN_FILE" <<EOF
-INCLUDE(CMakeForceCompiler)
-
-SET(CMAKE_SYSTEM_PROCESSOR xtensa)
-SET(CMAKE_FIND_ROOT_PATH ${TOOLCHAIN}/$TARGET)
-SET(CMAKE_STRIP :)
-
-CMAKE_FORCE_C_COMPILER(${PREFIX}gcc GNU)
+SET(CMAKE_SYSTEM_NAME Generic)
+SET(CMAKE_C_COMPILER  "${CROSS_COMPILE}gcc")
 EOF
 
 do_cmake() {
-	cmake -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_FILE "$@"
+	cmake -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" "$@"
 }
 
 mkdir -p build/k2 build/magpie


### PR DESCRIPTION
this is needed to make it work with debian
cross-toolchain

Signed-off-by: Paul Fertser <fercerpav@gmail.com>
Signed-off-by: Oleksij Rempel <linux@rempel-privat.de>