### PR TITLE
use minimal unmasked rate for multicast frames.

### DIFF
--- a/target_firmware/wlan/if_ath.c
+++ b/target_firmware/wlan/if_ath.c
@@ -759,6 +759,7 @@ static void tgt_HTCRecvMessageHandler(HTC_ENDPOINT_ID EndPt,
 
 	bf->bf_endpt = EndPt;
 	bf->bf_cookie = dh->cookie;
+	bf->vap_index = dh->vap_index;
 
 	if (tid->flag & TID_AGGR_ENABLED)
 		ath_tgt_handle_aggr(sc, bf);

--- a/target_firmware/wlan/if_athvar.h
+++ b/target_firmware/wlan/if_athvar.h
@@ -225,6 +225,7 @@ struct ath_tx_buf
 	HTC_ENDPOINT_ID       bf_endpt;
 	a_uint16_t            al_delta;
 	a_uint8_t             bf_cookie;
+	a_uint8_t			vap_index;
 };
 
 struct ath_rx_buf

--- a/target_firmware/wlan/if_owl.c
+++ b/target_firmware/wlan/if_owl.c
@@ -969,9 +969,13 @@ ath_tgt_tx_send_normal(struct ath_softc_tgt *sc, struct ath_tx_buf *bf)
 				      rcs, &isProbe);
 		ath_hal_memcpy(bf->bf_rcs, rcs, sizeof(rcs));
 	} else {
+		struct ath_vap_target *avp;
+
+		avp = &sc->sc_vap[bf->vap_index];
+
 		mrcs[1].tries = mrcs[2].tries = mrcs[3].tries = 0;
 		mrcs[1].rix = mrcs[2].rix = mrcs[3].rix = 0;
-		mrcs[0].rix   = 0;
+		mrcs[0].rix = ath_get_minrateidx(sc, avp);
 		mrcs[0].tries = 1;
 		mrcs[0].flags = 0;
 		ath_hal_memcpy(bf->bf_rcs, mrcs, sizeof(mrcs));


### PR DESCRIPTION
Current FW has ratemask interface and use it to set
minmal unmasked rate for beacons and mgmt frames.

This patch will allow to do the same with mcast.

Fallowing command will force mcast frames to be send with
54Mbit:
iw wlan0 set bitrates legacy-2.4 54

If multiple rate are set, then minimal rate will be used,
for example in this case 6Mbit:
iw wlan0 set bitrates legacy-2.4 6 54

This patch also should affect rate of injected frames.

Signed-off-by: Oleksij Rempel <linux@rempel-privat.de>