### PR TITLE
Add AppStream metadate file + use GNU FTP mirrors automagically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,30 @@
 GMP_VER=6.2.0
-GMP_URL=https://ftp.gnu.org/gnu/gmp/gmp-$(GMP_VER).tar.bz2
+GMP_URL=https://ftpmirror.gnu.org/gnu/gmp/gmp-$(GMP_VER).tar.bz2
 GMP_TAR=gmp-$(GMP_VER).tar.bz2
 GMP_DIR=gmp-$(GMP_VER)
 GMP_SUM=f51c99cb114deb21a60075ffb494c1a210eb9d7cb729ed042ddb7de9534451ea
 
 MPFR_VER=4.1.0
-MPFR_URL=https://ftp.gnu.org/gnu/mpfr/mpfr-$(MPFR_VER).tar.bz2
+MPFR_URL=https://ftpmirror.gnu.org/gnu/mpfr/mpfr-$(MPFR_VER).tar.bz2
 MPFR_TAR=mpfr-$(MPFR_VER).tar.bz2
 MPFR_DIR=mpfr-$(MPFR_VER)
 MPFR_SUM=feced2d430dd5a97805fa289fed3fc8ff2b094c02d05287fd6133e7f1f0ec926
 
 MPC_VER=1.1.0
-MPC_URL=https://ftp.gnu.org/gnu/mpc/mpc-$(MPC_VER).tar.gz
+MPC_URL=https://ftpmirror.gnu.org/gnu/mpc/mpc-$(MPC_VER).tar.gz
 MPC_TAR=mpc-$(MPC_VER).tar.gz
 MPC_DIR=mpc-$(MPC_VER)
 MPC_SUM=6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
 
 BINUTILS_VER=2.35
-BINUTILS_URL=https://ftp.gnu.org/gnu/binutils/binutils-$(BINUTILS_VER).tar.bz2
+BINUTILS_URL=https://ftpmirror.gnu.org/gnu/binutils/binutils-$(BINUTILS_VER).tar.bz2
 BINUTILS_TAR=binutils-$(BINUTILS_VER).tar.bz2
 BINUTILS_DIR=binutils-$(BINUTILS_VER)
 BINUTILS_PATCHES=local/patches/binutils-2.34_fixup.patch local/patches/binutils.patch
 BINUTILS_SUM=7d24660f87093670738e58bcc7b7b06f121c0fcb0ca8fc44368d675a5ef9cff7
 
 GCC_VER=10.2.0
-GCC_URL=https://ftp.gnu.org/gnu/gcc/gcc-$(GCC_VER)/gcc-$(GCC_VER).tar.gz
+GCC_URL=https://ftpmirror.gnu.org/gnu/gcc/gcc-$(GCC_VER)/gcc-$(GCC_VER).tar.gz
 GCC_TAR=gcc-$(GCC_VER).tar.gz
 GCC_DIR=gcc-$(GCC_VER)
 GCC_PATCHES=local/patches/gcc.patch

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -145,3 +145,6 @@ under the following licence:
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+The AppStream metadata file is subject to the copyright notice
+and license terms that it specifies.

--- a/com.qualcomm.qca.ath9k_htc.firmware.metainfo.xml
+++ b/com.qualcomm.qca.ath9k_htc.firmware.metainfo.xml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2020 John Scott <jscott@posteo.net>
+# SPDX-License-Identifier: FSFAP
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# This file provides AppStream metadata and should be installed in
+# /usr/share/metainfo/.
+
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="firmware">
+	<id>com.qualcomm.qca.ath9k_htc.firmware</id>
+	<metadata_license>FSFAP</metadata_license>
+	<name>Open ath9k_htc firmware</name>
+	<summary>Firmware for the Qualcomm Atheros AR7010 and AR9271 USB 802.11n NICs</summary>
+
+	<url type="homepage">https://github.com/qca/open-ath9k-htc-firmware</url>
+	<url type="bugtracker">https://github.com/qca/open-ath9k-htc-firmware/issues</url>
+	<url type="contact">mailto:ath9k_htc_fw@lists.infradead.org</url>
+	<update_contact>jscott@posteo.net</update_contact>
+
+	<provides>
+		<firmware type="runtime">ath9k_htc/htc_7010-1.4.0.fw</firmware>
+		<firmware type="runtime">ath9k_htc/htc_9271-1.4.0.fw</firmware>
+
+		# /sbin/modinfo -Falias ath9k_htc | sort
+		<modalias>usb:v040Dp3801d*</modalias>
+		<modalias>usb:v0411p017Fd*</modalias>
+		<modalias>usb:v0411p0197d*</modalias>
+		<modalias>usb:v0471p209Ed*</modalias>
+		<modalias>usb:v04CAp4605d*</modalias>
+		<modalias>usb:v04DAp3904d*</modalias>
+		<modalias>usb:v057Cp8403d*</modalias>
+		<modalias>usb:v07B8p9271d*</modalias>
+		<modalias>usb:v07D1p3A10d*</modalias>
+		<modalias>usb:v083ApA704d*</modalias>
+		<modalias>usb:v0846p9018d*</modalias>
+		<modalias>usb:v0846p9030d*</modalias>
+		<modalias>usb:v0930p0A08d*</modalias>
+		<modalias>usb:v0CF3p1006d*</modalias>
+		<modalias>usb:v0CF3p20FFd*</modalias>
+		<modalias>usb:v0CF3p7010d*</modalias>
+		<modalias>usb:v0CF3p7015d*</modalias>
+		<modalias>usb:v0CF3p9271d*</modalias>
+		<modalias>usb:v0CF3pB002d*</modalias>
+		<modalias>usb:v0CF3pB003d*</modalias>
+		<modalias>usb:v13D3p3327d*</modalias>
+		<modalias>usb:v13D3p3328d*</modalias>
+		<modalias>usb:v13D3p3346d*</modalias>
+		<modalias>usb:v13D3p3348d*</modalias>
+		<modalias>usb:v13D3p3349d*</modalias>
+		<modalias>usb:v13D3p3350d*</modalias>
+		<modalias>usb:v1668p1200d*</modalias>
+		<modalias>usb:v1EDAp2315d*</modalias>
+	</provides>
+</component>


### PR DESCRIPTION
I wrote a spruced-up AppStream metadata file and am submitting it upstream where it belongs. It will help users get the firmware installed among other benefits, especially those whom may not know they need it, and seems to've been successful in Debian.