### PR TITLE
Remove last instance of BSD-4 advertisement clause

### DIFF
--- a/target_firmware/wlan/if_llc.h
+++ b/target_firmware/wlan/if_llc.h
@@ -50,10 +50,6 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
  * 4. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.


### PR DESCRIPTION
The Regents of the University of California allowed their BSD-4-clause
licensed code to delete the 3rd clause via a copyright addendum which is
described at https://www.freebsd.org/copyright/license.

For the file asf_queue.h, the 3rd clause was already removed, so remove it
in if_llc.h as well.

Signed-off-by: Bastian Germann <bage@debian.org>